### PR TITLE
internal/gtkcord/window/about: purge

### DIFF
--- a/internal/gtkcord/window/about/about.go
+++ b/internal/gtkcord/window/about/about.go
@@ -1,3 +1,0 @@
-package about
-
-func New() *gtk


### PR DESCRIPTION
It looks like a partial package was committed as part of e7b00c738450e4338f8ac37c195f8ce19da25f76. This breaks some tooling that interacts with ./... or attempts to build/test the whole module.