### PR TITLE
Update dependencies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,15 @@
 
 ### Dependencies
 
-gtkcord4 needs GTK4, gobject-introspection, and optionally libcanberra. If compiling, then the library
-headers are also required.
+Gtkcord4 needs the following dependencies met:
+
+```
+sudo dnf install golang gtk4-devel gobject-introspection gobject-introspection-devel
+```
+
+Optionally (but recommended) install `libcanberra`
+
+To build with libadwaita, you will need `libadwaita-devel`
 
 ### Pre-built Binary
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 Gtkcord4 needs the following dependencies met:
 
 ```
-sudo dnf install golang gtk4-devel gobject-introspection gobject-introspection-devel
+golang git gtk4-devel gobject-introspection gobject-introspection-devel
 ```
 
 Optionally (but recommended) install `libcanberra`


### PR DESCRIPTION
I've changed the dependencies section to now list every program the user must install to compile the program. The previous instructions were somewhat vague, and did not include `gobject-introspection-devel` or `gtk4-devel` which are important and can cause a build to fail.