### PR TITLE
Specify mobile compatibility for the phosh desktop

### DIFF
--- a/nix/xyz.diamondb.gtkcord4.desktop
+++ b/nix/xyz.diamondb.gtkcord4.desktop
@@ -10,3 +10,4 @@ Categories=GNOME;GTK;Network;Chat;
 StartupNotify=true
 DBusActivatable=true
 X-GNOME-UsesNotifications=true
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
This shows gtkcord4 as a mobile-compatible app and displays it without any tweaks in the app drawer for Phosh, as mentioned in https://puri.sm/posts/specify-form-factors-in-your-librem-5-apps/