### PR TITLE
add nix/so.libdb.gtkcord4.desktop

### DIFF
--- a/nix/so.libdb.gtkcord4.desktop
+++ b/nix/so.libdb.gtkcord4.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=gtkcord4
+GenericName=Discord Chat
+Comment=A Discord client in Go and GTK4
+Exec=gtkcord4
+Icon=gtkcord4
+Terminal=false
+Type=Application
+Categories=GNOME;GTK;Network;Chat;
+StartupNotify=true
+DBusActivatable=true
+X-GNOME-UsesNotifications=true
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
I forgot to add this for the flatpak part of #156 

The .desktop file for the flatpak takes from here. I could set the flatpak manifest to rename downstream, but I think it'd be better to have the .desktop file available upstream, especially since it will be used for nix later anyway.