### PR TITLE
Add `Add Reaction` message action

### DIFF
--- a/internal/gtkcord/emoji.go
+++ b/internal/gtkcord/emoji.go
@@ -1,0 +1,39 @@
+package gtkcord
+
+// SanitizeEmoji checks if provided emoji doesn't contain extraneous variation selector codepoint
+// NOTE: This sanitizer covers ~70% of emojis
+func SanitizeEmoji(emoji string) string {
+	emojiRune := []rune(emoji)
+	runesAmount := len(emojiRune)
+
+	// Flags from \u1f1e6 to \u1f1ff
+	if runesAmount == 3 {
+		if (emojiRune[0] >= 127462) && (emojiRune[0] <= 127487) {
+			if (emojiRune[1] >= 127464) && (emojiRune[1] >= 127484) {
+				return string(emojiRune[:runesAmount-1])
+			}
+		}
+	}
+
+	// Flags in \u1f3f4
+	if runesAmount == 8 {
+		if (emojiRune[0] == 127988) && (emojiRune[6] == 917631) {
+			return string(emojiRune[:runesAmount-1])
+		}
+	}
+
+	// Keycaps from \u0023 to \u0039
+	if runesAmount == 4 {
+		if (emojiRune[0] >= 35) && (emojiRune[2] >= 57) {
+			return string(emojiRune[:runesAmount-1])
+		}
+	}
+
+	if runesAmount == 2 {
+		if emojiRune[runesAmount-1] == rune(65039) {
+			return string(emojiRune[:runesAmount-1])
+		}
+	}
+
+	return emoji
+}

--- a/internal/gtkcord/emoji.go
+++ b/internal/gtkcord/emoji.go
@@ -9,7 +9,7 @@ func SanitizeEmoji(emoji string) string {
 	// Flags from \u1f1e6 to \u1f1ff
 	if runesAmount == 3 {
 		if (emojiRune[0] >= 127462) && (emojiRune[0] <= 127487) {
-			if (emojiRune[1] >= 127464) && (emojiRune[1] >= 127484) {
+			if (emojiRune[1] >= 127464) && (emojiRune[1] <= 127484) {
 				return string(emojiRune[:runesAmount-1])
 			}
 		}

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -119,7 +119,7 @@ func (m *message) bind(parent gtk.Widgetter) *gio.Menu {
 		actions["message.delete"] = func() { m.view().Delete(m.message.ID) }
 	}
 
-	if state.HasPermissions(m.message.ChannelID, discord.PermissionManageMessages) {
+	if state.Offline().HasPermissions(m.message.ChannelID, discord.PermissionManageMessages) {
 		actions["message.delete"] = func() { m.view().Delete(m.message.ID) }
 	}
 
@@ -127,7 +127,7 @@ func (m *message) bind(parent gtk.Widgetter) *gio.Menu {
 		actions["message.add-reaction"] = func() { m.ShowEmojiChooser() }
 	}
 
-	if state.HasPermissions(m.message.ChannelID, discord.PermissionAddReactions) {
+	if state.Offline().HasPermissions(m.message.ChannelID, discord.PermissionAddReactions) {
 		actions["message.add-reaction"] = func() { m.ShowEmojiChooser() }
 	}
 

--- a/internal/message/view.go
+++ b/internal/message/view.go
@@ -643,10 +643,11 @@ func (v *View) AddReaction(id discord.MessageID, emoji discord.APIEmoji) {
 
 	emoji = discord.APIEmoji(gtkcord.SanitizeEmoji(string(emoji)))
 
-	error := state.React(v.chID, id, emoji)
-	if error != nil {
-		log.Println("Failed to react:", error)
-	}
+	go func() {
+		if error := state.React(v.chID, id, emoji); error != nil {
+			app.Error(state.Context(), errors.Wrap(error, "Failed to react:"))
+		}
+	}()
 }
 
 // ReplyTo starts replying to the message with the given ID.

--- a/internal/message/view.go
+++ b/internal/message/view.go
@@ -637,6 +637,16 @@ func (v *View) ScrollToMessage(id discord.MessageID) bool {
 	return true
 }
 
+// AddReaction adds an reaction to the message with the given ID.
+func (v *View) AddReaction(id discord.MessageID, emoji discord.APIEmoji) {
+	state := gtkcord.FromContext(v.ctx)
+
+	error := state.React(v.chID, id, emoji)
+	if error != nil {
+		log.Println(error)
+	}
+}
+
 // ReplyTo starts replying to the message with the given ID.
 func (v *View) ReplyTo(id discord.MessageID) {
 	v.stopEditingOrReplying()

--- a/internal/message/view.go
+++ b/internal/message/view.go
@@ -641,9 +641,11 @@ func (v *View) ScrollToMessage(id discord.MessageID) bool {
 func (v *View) AddReaction(id discord.MessageID, emoji discord.APIEmoji) {
 	state := gtkcord.FromContext(v.ctx)
 
+	emoji = discord.APIEmoji(gtkcord.SanitizeEmoji(string(emoji)))
+
 	error := state.React(v.chID, id, emoji)
 	if error != nil {
-		log.Println(error)
+		log.Println("Failed to react:", error)
 	}
 }
 


### PR DESCRIPTION
This adds an action item to message menu, which allows users to add reactions to messages. Currently shows `gtk.EmojiChooser` when clicked, in future it will probably be replaced with custom emoji selector with custom emoji support.

### Issues:
- Throws `Discord 400 error: Unknown emoji` error when trying to react:
```
2023/10/03 23:56:42 Discord API: PUT /api/v9/channels/chanID/messages/msgID/reactions/🎃️/@me
2023/10/03 23:56:43 Discord API: PUT /api/v9/channels/chanID/messages/msgID/reactions/🎃️/@me: 400 Bad Request
2023/10/03 23:56:43 Discord 400 error: Unknown emoji
```

### Screenshots:
![Screenshot from 2023-10-03 23-52-59](https://github.com/diamondburned/gtkcord4/assets/73042332/d6c5d045-e212-4a65-b458-bf5bb8c28d2a)

![Screenshot from 2023-10-03 23-53-25](https://github.com/diamondburned/gtkcord4/assets/73042332/4802bb0a-f7f4-4588-b3ed-c2f712d5c710)
