### PR TITLE
Add `navigation-sidebar` to DM channels list

### DIFF
--- a/internal/sidebar/direct/view.go
+++ b/internal/sidebar/direct/view.go
@@ -57,7 +57,7 @@ func NewChannelView(ctx context.Context, ctrl Opener) *ChannelView {
 	}
 
 	v.list = gtk.NewListBox()
-	v.list.AddCSSClass("direct-list")
+	v.list.SetCSSClasses([]string{"direct-list", "navigation-sidebar"})
 	v.list.SetHExpand(true)
 	v.list.SetSortFunc(v.sort)
 	v.list.SetFilterFunc(v.filter)


### PR DESCRIPTION
Just a small style change, but it makes DM channels list look much better

### Screenshot:
#### Before:
![Screenshot from 2023-10-12 21-25-07](https://github.com/diamondburned/gtkcord4/assets/73042332/9243e850-7b94-4a02-b840-d744b9295e16)

#### After:
![Screenshot from 2023-10-12 21-17-30](https://github.com/diamondburned/gtkcord4/assets/73042332/e82719cb-54ca-44a5-bdd9-e36706b4a4ef)