### PR TITLE
Add dbus service file

### DIFF
--- a/nix/so.libdb.gtkcord4.service
+++ b/nix/so.libdb.gtkcord4.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=so.libdb.gtkcord4
+Exec=/usr/bin/gtkcord4 --gapplication-service


### PR DESCRIPTION
This allows for launching via the desktop file with `DBusActivable=true` on DEs that support it.

https://wiki.gnome.org/HowDoI/DBusApplicationLaunching#Install_a_D-Bus_service_file

Closes #119